### PR TITLE
Feature: single graph toggle 

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-dropdown": "^1.6.4",
     "react-ga": "^2.5.7",
     "react-scripts": "2.1.5",
+    "react-switch": "^5.0.1",
     "recharts": "^1.5.0"
   },
   "scripts": {

--- a/src/components/Comparison.jsx
+++ b/src/components/Comparison.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { LineChart, Line, Tooltip, YAxis, ReferenceLine, ResponsiveContainer } from 'recharts';
+import { ProviderIdToColor, ProviderIdToName } from '../mappings';
+const cloudProviders = ["AWS", "IBM", "GCP", "AZURE", "CF"]
+
+const CustomTooltipFasterOnTop = ({ active, payload, label }) => {
+    const byValue = (({value: a}, {value: b})=> a > b ? 1 : -1)
+    const tooltipStyle = {
+        "padding": "10px",
+        "background-color": "rgb(255, 255, 255)",
+        "border": "1px solid rgb(204, 204, 204)",
+        "white-space": "nowrap"}
+    
+    if (active) {
+      return (
+        <div className="custom-tooltip" style={tooltipStyle}>
+           {payload.sort(byValue).map((x, i)=> {
+                const style = {color: x.color}
+                if (i === 0) {
+                    style['font-weight'] = "bolder"
+                    style['font-size'] = "larger"
+                }
+                return <p key={i} style={style} className="label">{`${x.name} : ${x.value.toFixed(0)}ms`}</p>
+            })
+           }
+        </div>
+      );
+    }
+  
+    return null;
+  };
+
+const ComparisonChart = ({data}) => {
+    const getLine = (p, i) => <Line key={i} name={ProviderIdToName.get(p)} type="monotone" dataKey={p} stroke={ProviderIdToColor.get(p)}  dot={false} />
+    return (
+        <ResponsiveContainer  width="100%" height={100} >
+            <LineChart data={data}>
+                <YAxis unit="ms" type="number" domain={[0, dataMax => (dataMax).toFixed(0)]} width={80} hide/>
+                <ReferenceLine x={90} stroke="#b8c2cc" strokeDasharray="2 4" />
+                <ReferenceLine x={50} stroke="#606f7b" strokeDasharray="2 4" />
+                <ReferenceLine x={99} stroke="#b8c2cc" strokeDasharray="2 4" />
+                <Tooltip content={<CustomTooltipFasterOnTop/>} />
+                { cloudProviders.map((p,i) => getLine(p,i))}
+            </LineChart>
+        </ResponsiveContainer>
+    )
+}
+
+const Comparison = ({ data, concurrency }) => {
+    const getData = provider => data.find(x => x.resource.provider === provider && x.job.concurrency === concurrency);
+    const comparisonData = [];
+    cloudProviders.forEach(provider => {
+        const data = getData(provider)
+        const {overheadMetrics} = data
+
+        overheadMetrics.percentiles.forEach((val, index) => {
+            const dataPoint = comparisonData[index] || { name: index };
+            dataPoint[provider] = val;
+            comparisonData[index] = dataPoint
+        })
+    });
+
+    return (
+        <ComparisonChart  data={comparisonData} />
+    );
+}
+
+export default Comparison;

--- a/src/sections/Coldstart.jsx
+++ b/src/sections/Coldstart.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import Label from '../components/Label';
 import Metric from '../components/Metric';
 import { LineChart, Line, Tooltip, YAxis, ReferenceLine, ResponsiveContainer } from 'recharts';
@@ -7,6 +7,8 @@ import ProviderName from '../components/ProviderName';
 import Slice from '../components/Slice';
 import { ProviderIdToColor } from '../mappings';
 import Card from '../components/Card';
+import Comparison from '../components/Comparison';
+import Switch from "react-switch";
 
 const Chart = ({ data }) => {
     const values = data.overheadMetrics.percentiles.map((value, idx) => ({ name: `Percentile #${idx}`, value }))
@@ -25,7 +27,13 @@ const Chart = ({ data }) => {
     )
 }
 
-const Provider = ({ data }) => {
+const Coldstart = ({metrics}) => {
+  const concurrency = 10;
+  const [showSingelGraphComaprison, setShowSingelGraphComaprison] = useState(false)
+  const data = metrics['job-coldstart-01'];
+  const getData = resourceId => data.find(x => x.resource.id === resourceId && x.job.concurrency === 10);
+
+  const Provider = ({ data }) => {
     return (
         <Slice>
             <Metric value={Math.round(data.overheadMetrics.percentiles[50]) + 'ms'} label="median" className="mb-2" />
@@ -34,18 +42,32 @@ const Provider = ({ data }) => {
                 <Metric value={Math.round(data.count.coldstart) + '#'} label="actual cold" small className="mb-2" />
                 <Metric value={Math.round(data.count.warm) + '#'} label="warm" small className="mb-2" />
             </div>
-            <Chart data={data} />
+            {!showSingelGraphComaprison &&
+                <Chart data={data} />
+            }
             <ProviderName id={data.resource.provider} />
         </Slice>
     )
-}
-
-const Coldstart = ({metrics}) => {
-  const data = metrics['job-coldstart-01'];
-  const getData = resourceId => data.find(x => x.resource.id === resourceId && x.job.concurrency === 10);
+  }
 
   const RightComponents = () => (<Fragment>
-    <Label name="Concurrency" value={10} color="blue" />
+    <label class="mr-2">Single Graph</label>
+    <Switch
+        checked={showSingelGraphComaprison}
+        onChange={()=> setShowSingelGraphComaprison(!showSingelGraphComaprison) }
+        onColor="#86d3ff"
+        onHandleColor="#2693e6"
+        handleDiameter={30}
+        uncheckedIcon={false}
+        checkedIcon={false}
+        boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+        activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+        height={20}
+        width={48}
+        className="react-switch mr-2"
+        id="material-switch"
+    />
+    <Label name="Concurrency" value={concurrency} color="blue" />
 </Fragment>);
 
   return (
@@ -58,6 +80,9 @@ const Coldstart = ({metrics}) => {
           <Provider data={getData('azurecs')} />
           <Provider data={getData('cf')} />
       </CardSection>
+      {showSingelGraphComaprison &&
+          <Comparison data={data} concurrency={concurrency}/>
+      }
     </Card>
   );
 }

--- a/src/sections/overhead/Percentiles.jsx
+++ b/src/sections/overhead/Percentiles.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import Label from '../../components/Label';
 import Metric from '../../components/Metric';
 import { LineChart, Line, Tooltip, YAxis, ReferenceLine, ResponsiveContainer } from 'recharts';
@@ -6,6 +6,8 @@ import CardSection from '../../components/CardSection';
 import ProviderName from '../../components/ProviderName';
 import Slice from '../../components/Slice';
 import { ProviderIdToColor } from '../../mappings';
+import Switch from "react-switch";
+import Comparison from '../../components/Comparison';
 
 const Chart = ({ data }) => {
     const values = data.overheadMetrics.percentiles.map((value, idx) => ({ name: `Percentile #${idx}`, value }))
@@ -24,40 +26,63 @@ const Chart = ({ data }) => {
     )
 }
 
-const Provider = ({ data }) => {
-    return (
-        <Slice>
-            <Metric value={Math.round(data.overheadMetrics.percentiles[50]) + 'ms'} label="median" className="mb-2" />
-            <Metric value={Math.round(data.overheadMetrics.percentiles[100]) + 'ms'} label="max" small className="mb-2" />
-            <div className="flex justify-between">
-                <Metric value={Math.round(data.overheadMetrics.percentiles[90]) + 'ms'} label="90th percentile" small className="mb-2" />
-                <Metric value={Math.round(data.overheadMetrics.percentiles[99]) + 'ms'} label="99th percentile" small className="mb-2" />
-            </div>
-            <Chart data={data} />
-            <ProviderName id={data.resource.provider} />
-        </Slice>
-    )
-}
-
-
-const Percentiles = ({ data, concurrency }) => {
+const Percentiles = ({ data, concurrency, hideGraphs }) => {
     const getData = resourceId => data.find(x => x.resource.id === resourceId && x.job.concurrency === concurrency);
+    const [showSingelGraphComaprison, setShowSingelGraphComaprison] = useState(false)
 
     const RightComponents = () => (<Fragment>
+        <label class="mr-2">Single Graph</label>
+        <Switch
+          checked={showSingelGraphComaprison}
+          onChange={()=> setShowSingelGraphComaprison(!showSingelGraphComaprison) }
+          onColor="#86d3ff"
+          onHandleColor="#2693e6"
+          handleDiameter={30}
+          uncheckedIcon={false}
+          checkedIcon={false}
+          boxShadow="0px 1px 5px rgba(0, 0, 0, 0.6)"
+          activeBoxShadow="0px 0px 1px 10px rgba(0, 0, 0, 0.2)"
+          height={20}
+          width={48}
+          className="react-switch mr-2"
+          id="material-switch"
+        />
         <Label name="Concurrency" value={concurrency} color="blue" margin />
         <Label name="only hot" color="red" margin />
         <Label name="last 3 days" color="green" />
 
     </Fragment>)
 
+    const Provider = ({ data }) => {
+        return (
+            <Slice>
+                <Metric value={Math.round(data.overheadMetrics.percentiles[50]) + 'ms'} label="median" className="mb-2" />
+                <Metric value={Math.round(data.overheadMetrics.percentiles[100]) + 'ms'} label="max" small className="mb-2" />
+                <div className="flex justify-between">
+                    <Metric value={Math.round(data.overheadMetrics.percentiles[90]) + 'ms'} label="90th percentile" small className="mb-2" />
+                    <Metric value={Math.round(data.overheadMetrics.percentiles[99]) + 'ms'} label="99th percentile" small className="mb-2" />
+                </div>
+                {!showSingelGraphComaprison &&
+                    <Chart data={data} />
+                }         
+                <ProviderName id={data.resource.provider} />
+            </Slice>
+        )
+    }
+
     return (
-        <CardSection title="Percentiles" rightComponents={RightComponents}>
-            <Provider data={getData('aws1024')} />
-            <Provider data={getData('gcp1024')} />
-            <Provider data={getData('ibm1024')} />
-            <Provider data={getData('azure')} />
-            <Provider data={getData('cf')} />
-        </CardSection>
+        <Fragment>
+            <CardSection title="Percentiles" rightComponents={RightComponents}>
+                <Provider data={getData('aws1024')}  />
+                <Provider data={getData('gcp1024')} />
+                <Provider data={getData('ibm1024')}  />
+                <Provider data={getData('azure')} />
+                <Provider data={getData('cf')} />
+            </CardSection>
+            {showSingelGraphComaprison && 
+                <Comparison data={data} concurrency={concurrency}/>
+            }
+        </Fragment>
     );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8627,6 +8627,13 @@ react-smooth@~1.0.0:
     raf "^3.4.0"
     react-transition-group "^2.5.0"
 
+react-switch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-switch/-/react-switch-5.0.1.tgz#449277f4c3aed5286fffd0f50d5cbc2a23330406"
+  integrity sha512-Pa5kvqRfX85QUCK1Jv0rxyeElbC3aNpCP5hV0LoJpU/Y6kydf0t4kRriQ6ZYA4kxWwAYk/cH51T4/sPzV9mCgQ==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-transition-group@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.6.0.tgz#3c41cbdd9c044c5f8604d4e8d319e860919c9fae"


### PR DESCRIPTION
### TL;DR
new feature 
+ single graph comparison
+ clear label that makes it easy to distinguish the fastest provider
+ toggle to switch between views

### Description:
Hi Bernd

as discussed I added a new view that doesn't overload the existing view, 
but still provides a single graph comparison of all providers.
so a single graph comparison
with a clear label that makes it easy to distinguish the fastest provider
and a toggle to switch between the single graph to the individual provider graphs which are more esthetic but does not tell us much as they are on different scale :)
the toggle is off by default.

### snapshots:
<img width="1196" alt="Screen Shot 2019-12-23 at 14 29 30" src="https://user-images.githubusercontent.com/13344801/71358489-c7c0ac00-2591-11ea-87f9-3aa95c7e156f.png">
<img width="1196" alt="Screen Shot 2019-12-23 at 14 30 20" src="https://user-images.githubusercontent.com/13344801/71358490-c8594280-2591-11ea-80f5-63137ae1bbc9.png">
<img width="1196" alt="Screen Shot 2019-12-23 at 14 30 33" src="https://user-images.githubusercontent.com/13344801/71358491-c8594280-2591-11ea-86cf-82b90b912b6d.png">

